### PR TITLE
Add Ansible playbook for automating Raspberry Pi setup with Klipper

### DIFF
--- a/SetupRaspberryPi.md
+++ b/SetupRaspberryPi.md
@@ -71,6 +71,12 @@ Your **SD card is now ready for the Pi**.
 
 ---
 
+## Ansible Playbook
+
+Alternatively, you can automate the Raspberry Pi setup using the provided Ansible playbook located in [`ansible/configure-tunneled-raspberry-pi`](ansible/configure-tunneled-raspberry-pi). This playbook will automatically configure your Raspberry Pi 4 or 5 with all the necessary settings for Klipper.
+
+See the [Ansible playbook README](ansible/configure-tunneled-raspberry-pi/README.md) for detailed instructions on how to use it.
+
 ---
 
 # ⚡ Raspberry Pi 4 Setup

--- a/ansible/configure-tunneled-raspberry-pi/README.md
+++ b/ansible/configure-tunneled-raspberry-pi/README.md
@@ -1,0 +1,181 @@
+# Klipper Raspberry Pi 4/5 Ansible Playbook
+
+This Ansible playbook configures a Raspberry Pi 4 or Raspberry Pi 5 for use with Klipper 3D printer firmware. It sets up USB Gadget Mode to create virtual serial interfaces that Klipper can use to communicate with 3D printers.
+
+## Overview
+
+The playbook performs the following configurations:
+- Enables SPI and configures boot settings for optimal Klipper performance
+- Loads required kernel modules (`dwc2`, `libcomposite`)
+- Creates a USB gadget with multiple serial ACM interfaces
+- Sets up a systemd service that automatically configures USB interfaces at boot
+
+## Structure
+
+```
+vanilla-klipper/
+├── README.md                           # This file
+├── inventory.yaml                      # Ansible inventory with Raspberry Pi configuration
+├── playbook.yaml                       # Main playbook
+├── vanilla-klipper-raspberry-pi-4/     # Ansible role for Raspberry Pi 4
+│   ├── files/
+│   │   ├── config.txt                  # Raspberry Pi 4 boot configuration
+│   │   ├── ports.service               # Systemd service unit
+│   │   └── ports.sh                    # USB gadget configuration script
+│   ├── handlers/
+│   │   └── main.yaml                   # Reboot handler
+│   ├── tasks/
+│   │   └── main.yaml                   # Main tasks of the role
+│   └── templates/
+│       └── modules.j2                  # Kernel modules template
+└── vanilla-klipper-raspberry-pi-5/     # Ansible role for Raspberry Pi 5
+    ├── files/
+    │   ├── config.txt                  # Raspberry Pi 5 boot configuration
+    │   ├── ports.service               # Systemd service unit
+    │   └── ports.sh                    # USB gadget configuration script
+    ├── handlers/
+    │   └── main.yaml                   # Reboot handler
+    ├── tasks/
+    │   └── main.yaml                   # Main tasks of the role
+    └── templates/
+        └── modules.j2                  # Kernel modules template
+```
+
+## Prerequisites
+
+- Ansible 2.9 or higher
+- Raspberry Pi 4 or Raspberry Pi 5 with Raspberry Pi OS
+- SSH access to the Raspberry Pi
+- Sudo privileges on the Raspberry Pi
+
+## Installation and Usage
+
+### 1. Configure Playbook
+
+Edit the `playbook.yaml` file and uncomment the appropriate role for your Raspberry Pi model:
+
+**For Raspberry Pi 4:**
+```yaml
+- hosts: raspberrypi
+  become: true
+  roles:
+    - vanilla-klipper-raspberry-pi-4
+    # - vanilla-klipper-raspberry-pi-5
+```
+
+**For Raspberry Pi 5:**
+```yaml
+- hosts: raspberrypi
+  become: true
+  roles:
+    # - vanilla-klipper-raspberry-pi-4
+    - vanilla-klipper-raspberry-pi-5
+```
+
+### 2. Configure Inventory
+
+Edit the `inventory.yaml` file and enter your Raspberry Pi details:
+
+```yaml
+all:
+  hosts:
+    raspberrypi:
+      ansible_host: <YOUR_RASPBERRY_PI_IP>
+      ansible_user: <YOUR_SSH_USER>
+      ansible_port: 22
+      ansible_password: <YOUR_PASSWORD>
+      ansible_become: true
+      # ansible_ssh_private_key_file: <YOUR_PRIVATE_KEY_FILE>
+```
+
+**Note:** For better security, use SSH keys instead of passwords.
+
+### 3. Run Playbook
+
+```bash
+ansible-playbook -i inventory.yaml playbook.yaml
+```
+
+The playbook will automatically restart the Raspberry Pi to activate the boot configuration.
+
+### 4. Verify Results
+
+After reboot, the following USB devices should be available:
+- `/dev/ttyACM0` - First serial interface
+- `/dev/ttyACM1` - Second serial interface  
+- `/dev/ttyACM2` - Third serial interface (for ACE Pro)
+
+## Ansible Roles Details
+
+This playbook includes two separate roles optimized for different Raspberry Pi models:
+
+### vanilla-klipper-raspberry-pi-4 Role
+
+Customized for **Raspberry Pi 4**:
+
+#### Tasks
+1. **Boot Configuration**: Copies optimized `config.txt` for Raspberry Pi 4
+2. **Kernel Modules**: Configures `/etc/modules` with `dwc2` and `libcomposite`
+3. **USB Gadget Script**: Installs the configuration script to `/opt/ports.sh`
+4. **Systemd Service**: Sets up `ports.service` for automatic startup
+5. **Service Activation**: Starts and enables the ports.service
+
+#### Configuration Files
+- **config.txt**: Enables SPI, optimized for 64-bit mode
+- **ports.sh**: Creates USB gadget with 3 ACM serial interfaces
+- **ports.service**: Systemd service unit for automatic startup
+
+### vanilla-klipper-raspberry-pi-5 Role
+
+Customized for **Raspberry Pi 5**:
+
+#### Tasks
+The tasks are the same as those in the Raspberry Pi 4 playbook.
+
+#### Configuration Files
+- **config.txt**: Raspberry Pi 5-specific boot configuration
+- **ports.sh**: Same configuration as for Raspberry Pi 4
+- **ports.service**: Same configuration as for Raspberry Pi 4
+
+### Common Features
+
+Both roles include:
+- **Handlers**: `reboot_pi` - Restarts the Raspberry Pi after boot configuration changes
+- **USB Gadget Creation**: Creates virtual serial interfaces for Klipper communication
+- **Automatic Service Management**: Ensures services start on boot and restart on failure
+
+## Troubleshooting
+
+### USB Gadget not working
+1. Check if modules are loaded:
+   ```bash
+   lsmod | grep -E "dwc2|libcomposite"
+   ```
+
+2. Check service status:
+   ```bash
+   sudo systemctl status ports.service
+   ```
+
+3. Check USB devices:
+   ```bash
+   ls -la /dev/ttyACM*
+   ```
+
+### Raspberry Pi won't boot
+- Check `config.txt` for syntax errors
+- Ensure the correct role is uncommented in `playbook.yaml` for your Pi model
+- Verify that the Raspberry Pi model being used matches the selected role
+
+### Wrong role selected
+- If you're using Raspberry Pi 4, ensure `vanilla-klipper-raspberry-pi-4` is uncommented
+- If you're using Raspberry Pi 5, ensure `vanilla-klipper-raspberry-pi-5` is uncommented
+- Only one role should be active at a time in the playbook
+
+## Supported Hardware
+
+### Raspberry Pi 4 Role (`vanilla-klipper-raspberry-pi-4`)
+- Raspberry Pi 4 Model B (all RAM variants)
+
+### Raspberry Pi 5 Role (`vanilla-klipper-raspberry-pi-5`)
+- Raspberry Pi 5 (all RAM variants)

--- a/ansible/configure-tunneled-raspberry-pi/inventory.yaml
+++ b/ansible/configure-tunneled-raspberry-pi/inventory.yaml
@@ -1,0 +1,9 @@
+all:
+  hosts:
+    raspberrypi:
+      ansible_host: <YOUR_RASPBERRY_PI_IP>
+      ansible_user: <YOUR_SSH_USER>
+      ansible_port: 22
+      ansible_password: <YOUR_PASSWORD>
+      ansible_become: true
+      # ansible_ssh_private_key_file: <YOUR_PRIVATE_KEY_FILE>

--- a/ansible/configure-tunneled-raspberry-pi/playbook.yaml
+++ b/ansible/configure-tunneled-raspberry-pi/playbook.yaml
@@ -1,0 +1,5 @@
+- hosts: raspberrypi
+  become: true
+  roles:
+    - vanilla-klipper-raspberry-pi-4
+    # - vanilla-klipper-raspberry-pi-5

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/files/config.txt
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/files/config.txt
@@ -1,0 +1,55 @@
+# For more options and information see
+# http://rptl.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+dtparam=spi=on
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Additional overlays and parameters are documented
+# /boot/firmware/overlays/README
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Automatically load initramfs files, if found
+auto_initramfs=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Don't have the firmware create an initial video= setting in cmdline.txt.
+# Use the kernel's default instead.
+disable_fw_kms_setup=1
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+# Run as fast as firmware / board allows
+arm_boost=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+
+# Disabled for klipper S1
+#otg_mode=1
+
+[cm5]
+#dtoverlay=dwc2,dr_mode=host
+
+[all]
+dtoverlay=dwc2
+enable_uart=1

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/files/ports.service
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/files/ports.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=USB Serial Bridge Script
+After=network.target syslog.target
+
+[Service]
+Type=simple
+ExecStart=/opt/ports.sh
+User=root
+WorkingDirectory=/opt
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/files/ports.sh
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/files/ports.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+modprobe libcomposite
+cd /sys/kernel/config/usb_gadget/
+mkdir -p klipper
+cd klipper
+
+echo 0x1d6b > idVendor
+echo 0x0104 > idProduct
+echo 0x0100 > bcdDevice
+echo 0x0200 > bcdUSB
+
+mkdir -p strings/0x409
+echo "1234567890" > strings/0x409/serialnumber
+echo "KlipperPi" > strings/0x409/manufacturer
+echo "VirtualSerialBridge" > strings/0x409/product
+
+mkdir -p configs/c.1/strings/0x409
+echo "Config 1" > configs/c.1/strings/0x409/configuration
+
+# First serial interface
+mkdir functions/acm.usb0
+ln -s functions/acm.usb0 configs/c.1/
+
+# Second serial interface
+mkdir functions/acm.usb1
+ln -s functions/acm.usb1 configs/c.1/
+
+# Third serial interface for ACE Pro
+mkdir functions/acm.usb2
+ln -s functions/acm.usb2 configs/c.1/
+
+# Bind to UDC
+echo $(ls /sys/class/udc) > UDC

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/handlers/main.yaml
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/handlers/main.yaml
@@ -1,0 +1,3 @@
+- name: reboot_pi
+  reboot:
+    msg: "Reboot nach Änderung der config.txt"

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/tasks/main.yaml
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/tasks/main.yaml
@@ -1,0 +1,25 @@
+- name: Schreibe config.txt
+  copy:
+    src: config.txt
+    dest: /boot/firmware/config.txt
+  notify: reboot_pi
+- name: Schreibe /etc/modules
+  template:
+    src: modules.j2
+    dest: /etc/modules
+- name: Erstelle ports.sh Skript
+  copy:
+    src: ports.sh
+    dest: /opt/ports.sh
+    mode: '0755'
+- name: ports.service Systemd Unit anlegen
+  copy:
+    src: ports.service
+    dest: /etc/systemd/system/ports.service
+- name: Systemd Daemon neu laden
+  command: systemctl daemon-reload
+- name: ports.service starten
+  systemd:
+    name: ports.service
+    state: started
+    enabled: yes

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/templates/modules.j2
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-4/templates/modules.j2
@@ -1,0 +1,2 @@
+dwc2
+libcomposite

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/files/config.txt
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/files/config.txt
@@ -1,0 +1,54 @@
+# For more options and information see
+# http://rptl.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Additional overlays and parameters are documented
+# /boot/firmware/overlays/README
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Automatically load initramfs files, if found
+auto_initramfs=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Don't have the firmware create an initial video= setting in cmdline.txt.
+# Use the kernel's default instead.
+disable_fw_kms_setup=1
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+# Run as fast as firmware / board allows
+arm_boost=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[cm5]
+dtoverlay=dwc2,dr_mode=host
+
+[all]
+
+[pi5]
+dtoverlay=dwc2

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/files/ports.service
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/files/ports.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=USB Serial Bridge Script
+After=network.target syslog.target
+
+[Service]
+Type=simple
+ExecStart=/opt/ports.sh
+User=root
+WorkingDirectory=/opt
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/files/ports.sh
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/files/ports.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+modprobe libcomposite
+cd /sys/kernel/config/usb_gadget/
+mkdir -p klipper
+cd klipper
+
+echo 0x1d6b > idVendor
+echo 0x0104 > idProduct
+echo 0x0100 > bcdDevice
+echo 0x0200 > bcdUSB
+
+mkdir -p strings/0x409
+echo "1234567890" > strings/0x409/serialnumber
+echo "KlipperPi" > strings/0x409/manufacturer
+echo "VirtualSerialBridge" > strings/0x409/product
+
+mkdir -p configs/c.1/strings/0x409
+echo "Config 1" > configs/c.1/strings/0x409/configuration
+
+# First serial interface
+mkdir functions/acm.usb0
+ln -s functions/acm.usb0 configs/c.1/
+
+# Second serial interface
+mkdir functions/acm.usb1
+ln -s functions/acm.usb1 configs/c.1/
+
+# Third serial interface for ACE Pro
+mkdir functions/acm.usb2
+ln -s functions/acm.usb2 configs/c.1/
+
+# Bind to UDC
+echo $(ls /sys/class/udc) > UDC

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/handlers/main.yaml
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/handlers/main.yaml
@@ -1,0 +1,3 @@
+- name: reboot_pi
+  reboot:
+    msg: "Reboot nach Änderung der config.txt"

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/tasks/main.yaml
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/tasks/main.yaml
@@ -1,0 +1,25 @@
+- name: Schreibe config.txt
+  copy:
+    src: config.txt
+    dest: /boot/firmware/config.txt
+  notify: reboot_pi
+- name: Schreibe /etc/modules
+  template:
+    src: modules.j2
+    dest: /etc/modules
+- name: Erstelle ports.sh Skript
+  copy:
+    src: ports.sh
+    dest: /opt/ports.sh
+    mode: '0755'
+- name: ports.service Systemd Unit anlegen
+  copy:
+    src: ports.service
+    dest: /etc/systemd/system/ports.service
+- name: Systemd Daemon neu laden
+  command: systemctl daemon-reload
+- name: ports.service starten
+  systemd:
+    name: ports.service
+    state: started
+    enabled: yes

--- a/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/templates/modules.j2
+++ b/ansible/configure-tunneled-raspberry-pi/vanilla-klipper-raspberry-pi-5/templates/modules.j2
@@ -1,0 +1,2 @@
+dwc2
+libcomposite


### PR DESCRIPTION
Basically took https://github.com/Kobra-S1/vanilla-klipper-swu/blob/main/SetupRaspberryPi.md and wrote an ansible-playbook with a raspbi-4 and raspbi-5 role (they only differ by the boot-config) for automated configuration.
