### PR TITLE
Enhance G9111: Skip purge if filament already loaded

### DIFF
--- a/releases/KS1/printer.tunneled-klipper.cfg
+++ b/releases/KS1/printer.tunneled-klipper.cfg
@@ -515,11 +515,7 @@ gcode:
     G92 E0
     M82
     
-# =======================
-# G9111 — Startup Macro: Smart-Purge (Memory + Sensor Check)
-# =======================
 [gcode_macro G9111]
-description: "Startup: G9111 with sensor check to detect manual unloading"
 variable_wipe_temp: 150
 variable_travel_speed: 200  # mm/s
 
@@ -533,17 +529,25 @@ gcode:
     {% set BEDTEMP = (bed_raw | replace('=', '', 1)) | float %}
     {% set EXTRUDERTEMP = (noz_raw | replace('=', '', 1)) | float %}
     {% set WIPETEMP = (wipe_raw | replace('=', '', 1)) | float %}
-
+    
     # --- SMART LOGIC START ---
-
-    # 1. What is stored in memory?
-    {% set ace_index = printer.save_variables.variables.ace_current_index|default(-1)|int %}
-    {% set filament_pos = printer.save_variables.variables.ace_filament_pos|default('none') %}
-
+    
+    # Safety check: Does save_variables exist? (Important for non-ACE users)
+    {% if printer.save_variables is defined and printer.save_variables.variables is defined %}
+        {% set ace_index = printer.save_variables.variables.ace_current_index|default(-1)|int %}
+        {% set filament_pos = printer.save_variables.variables.ace_filament_pos|default('none') %}
+    {% else %}
+        # Fallback if save_variables is missing -> Force Purge
+        {% set ace_index = -1 %}
+        {% set filament_pos = 'none' %}
+    {% endif %}
+    
     # 2. What does the sensor actually see?
-    # NOTE: Ensure this sensor name matches your printer.cfg!
-    {% set is_physically_loaded = printer["filament_switch_sensor filament_runout_nozzle"].filament_detected %}
-
+    {% set is_physically_loaded = False %}
+    {% if "filament_switch_sensor filament_runout_nozzle" in printer.configfile.settings %}
+         {% set is_physically_loaded = printer["filament_switch_sensor filament_runout_nozzle"].filament_detected %}
+    {% endif %}
+    
     {% set local_skip_purge = False %}
 
     {% if TOOL == ace_index and filament_pos == 'nozzle' and is_physically_loaded %}
@@ -566,7 +570,7 @@ gcode:
     RESPOND TYPE=echo MSG="Wait for pre-heat temp reached"
     TO_THROW_POSITION
     M109 S{WIPETEMP}
-
+    
     RESPOND TYPE=echo MSG="Wipe nozzle"
     WIPE_ENTER
     WIPE_NOZZLE
@@ -577,10 +581,10 @@ gcode:
     G90
     G28 Z
     M106 S255
-
+    
     RESPOND TYPE=echo MSG="Adaptive Bed Mesh"
     BED_MESH_CALIBRATE PROFILE=adaptive ADAPTIVE=1
-
+    
     # Final Heat
     RESPOND TYPE=echo MSG="Heat nozzle to print temperature"
     M106 S0
@@ -591,7 +595,7 @@ gcode:
     {% if printer["gcode_macro _ACE_STATE"] is defined %}
         SET_GCODE_VARIABLE MACRO=_ACE_STATE VARIABLE=startup_toolchange VALUE=1
     {% endif %}
-
+    
     # Tool Activation
     {% if TOOL >= 0 %}
         T{TOOL}


### PR DESCRIPTION
This PR improves the G9111 startup macro to prevent unnecessary purging.

**Changes:**
- Checks if the requested tool matches the stored `ace_current_index`.
- Checks if the physical filament sensor (`filament_runout_nozzle`) detects material.
- If both are true: Skips the purge line and performs a safety wipe only.
- If false (new tool or sensor empty): Performs standard purge and wipe.

**Note:**
This requires the updated `_ACE_POST_TOOLCHANGE` logic (see corresponding PR in ACEPRO repository) to correctly save the tool state variables.