### PR TITLE
Center the printhead above the poopshoot 

### DIFF
--- a/releases/KS1/printer.klipper.cfg
+++ b/releases/KS1/printer.klipper.cfg
@@ -477,21 +477,21 @@ gcode:
     G90
     G1 F20000
     G1 Y250
-    G1 X40
+    G1 X47
     G1 Y276
 
 [gcode_macro TO_FRONT_OF_THROW_BLADE]
 gcode:
     G90
     G1 F20000
-    G1 X40
+    G1 X47
     G1 Y250
 
 [gcode_macro TO_BACK_OF_THROW_BLADE]
 gcode:
     G90
     G1 F20000
-    G1 X40
+    G1 X47
     G1 Y265
 
 [gcode_macro MOVE_HEAT_POS]
@@ -499,7 +499,7 @@ gcode:
     G90
     G1 F20000
     G1 Y250
-    G1 X40
+    G1 X47
     G1 Y276
 
 [gcode_macro UNDERLINE]
@@ -578,7 +578,7 @@ gcode:
   RESPOND TYPE=echo MSG="Prime nozzle"
   G92 E0
   G1 E50 F400
-  G1 E60 F150
+  G1 E60 F150already though
   G1 E90 F150
   G92 E0
 

--- a/releases/KS1/printer.klipper.cfg
+++ b/releases/KS1/printer.klipper.cfg
@@ -578,7 +578,7 @@ gcode:
   RESPOND TYPE=echo MSG="Prime nozzle"
   G92 E0
   G1 E50 F400
-  G1 E60 F150already though
+  G1 E60 F150
   G1 E90 F150
   G92 E0
 

--- a/releases/KS1/printer.tunneled-klipper.cfg
+++ b/releases/KS1/printer.tunneled-klipper.cfg
@@ -484,14 +484,14 @@ gcode:
 gcode:
     G90
     G1 F20000
-    G1 X40
+    G1 X47
     G1 Y250
 
 [gcode_macro TO_BACK_OF_THROW_BLADE]
 gcode:
     G90
     G1 F20000
-    G1 X40
+    G1 X47
     G1 Y265
 
 [gcode_macro MOVE_HEAT_POS]
@@ -499,7 +499,7 @@ gcode:
     G90
     G1 F20000
     G1 Y250
-    G1 X40
+    G1 X47
     G1 Y276
 
 [gcode_macro UNDERLINE]


### PR DESCRIPTION
Right now the nozzle is put too far to the left in the poop shoot, introducing issues with mods that are clipped to the poop shoot, because the primed filament can flow onto these mods, causing blobs and clogs in the worst case.

The original position in the anycubic firmware is X47, thus changing it here to X47 adheres to the stock firmware and is nearly centered (the real center would be around X48 or X49 for me), but that of course could differ from printer to print